### PR TITLE
Create Currency Converter Bot for Telegram

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,0 +1,52 @@
+require('dotenv').config();
+const TelegramBot = require('node-telegram-bot-api');
+const axios = require('axios');
+
+// Replace with your actual Telegram Bot Token
+const token = process.env.TELEGRAM_BOT_TOKEN;
+const bot = new TelegramBot(token, { polling: true });
+
+// Replace with your actual Exchangerate API key
+const exchangerateApiKey = process.env.EXCHANGRATE_API_KEY;
+
+// Available currencies
+const currencies = ['UAH', 'USD', 'EUR', 'GBP', 'CHF', 'PLN'];
+
+bot.onText(/\/start/, (msg) => {
+    const chatId = msg.chat.id;
+    bot.sendMessage(chatId, 'Welcome to Currency Converter Bot! Please choose the currency:', {
+        reply_markup: {
+            inline_keyboard: [
+                currencies.map((currency) => ({
+                    text: currency,
+                    callback_data: currency,
+                })),
+            ],
+        },
+    });
+});
+
+bot.on('callback_query', async (query) => {
+    const chatId = query.message.chat.id;
+    const currency = query.data;
+
+    try {
+        const response = await axios.get(
+            `https://api.exchangerate-api.com/v4/latest/${currency}`,
+            { params: { apiKey: exchangerateApiKey } }
+        );
+
+        const rates = response.data.rates;
+        let message = `Exchange rates for 1 ${currency}:\n`;
+
+        currencies.forEach((cur) => {
+            if (cur !== currency) {
+                message += `${cur}: ${rates[cur]}\n`;
+            }
+        });
+
+        bot.sendMessage(chatId, message);
+    } catch (error) {
+        bot.sendMessage(chatId, 'Sorry, something went wrong. Please try again later.');
+    }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.2",
+        "dotenv": "^16.4.5",
         "node-telegram-bot-api": "^0.66.0"
       }
     },
@@ -359,6 +360,17 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -2058,6 +2070,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/segamegadrivee/currency-converter-tg-bot#readme",
   "dependencies": {
     "axios": "^1.7.2",
+    "dotenv": "^16.4.5",
     "node-telegram-bot-api": "^0.66.0"
   }
 }


### PR DESCRIPTION
Add functionality to convert between UAH, USD, EUR, GBP, CHF, PLN using Exchangerate API and node-telegram-bot-api. Include .env file for secure token management.