### PR TITLE
add a keyboard

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -11,42 +11,97 @@ const exchangerateApiKey = process.env.EXCHANGRATE_API_KEY;
 
 // Available currencies
 const currencies = ['UAH', 'USD', 'EUR', 'GBP', 'CHF', 'PLN'];
-
+ 
+// Store user selection state
+const userState = {};
+ 
+// Function to generate currency selection keyboard
+const generateCurrencyKeyboard = () => {
+  return {
+    keyboard: currencies.map((currency) => ([{ text: currency }])),
+    one_time_keyboard: true,
+  };
+};
+ 
+// Function to generate the confirm keyboard
+const generateConfirmKeyboard = () => {
+  return {
+    keyboard: [
+      [{ text: 'Confirm' }],
+      [{ text: 'Change Currency Pair' }],
+    ],
+    one_time_keyboard: true,
+  };
+};
+ 
+// Handle /start command
 bot.onText(/\/start/, (msg) => {
-    const chatId = msg.chat.id;
-    bot.sendMessage(chatId, 'Welcome to Currency Converter Bot! Please choose the currency:', {
-        reply_markup: {
-            inline_keyboard: [
-                currencies.map((currency) => ({
-                    text: currency,
-                    callback_data: currency,
-                })),
-            ],
-        },
-    });
+  const chatId = msg.chat.id;
+  bot.sendMessage(chatId, 'Welcome to Currency Converter Bot! Please choose the base currency:', {
+    reply_markup: generateCurrencyKeyboard(),
+  });
 });
-
-bot.on('callback_query', async (query) => {
-    const chatId = query.message.chat.id;
-    const currency = query.data;
-
-    try {
-        const response = await axios.get(
-            `https://api.exchangerate-api.com/v4/latest/${currency}`,
-            { params: { apiKey: exchangerateApiKey } }
-        );
-
-        const rates = response.data.rates;
-        let message = `Exchange rates for 1 ${currency}:\n`;
-
-        currencies.forEach((cur) => {
-            if (cur !== currency) {
-                message += `${cur}: ${rates[cur]}\n`;
-            }
-        });
-
-        bot.sendMessage(chatId, message);
-    } catch (error) {
-        bot.sendMessage(chatId, 'Sorry, something went wrong. Please try again later.');
+ 
+// Handle text messages
+bot.on('message', async (msg) => {
+  const chatId = msg.chat.id;
+  const text = msg.text;
+ 
+  // Check if user is selecting base currency
+  if (!userState[chatId] || !userState[chatId].baseCurrency) {
+    if (currencies.includes(text)) {
+      userState[chatId] = { baseCurrency: text };
+      bot.sendMessage(chatId, 'Please choose the target currency:', {
+        reply_markup: generateCurrencyKeyboard(),
+      });
+    } else {
+      bot.sendMessage(chatId, 'Please choose a valid base currency:', {
+        reply_markup: generateCurrencyKeyboard(),
+      });
     }
+    return;
+  }
+ 
+  // Check if user is selecting target currency
+  if (userState[chatId].baseCurrency && !userState[chatId].targetCurrency) {
+    if (currencies.includes(text) && text !== userState[chatId].baseCurrency) {
+      userState[chatId].targetCurrency = text;
+      bot.sendMessage(chatId, `You have selected ${userState[chatId].baseCurrency} to ${text}. Confirm or change the pair:`, {
+        reply_markup: generateConfirmKeyboard(),
+      });
+    } else {
+      bot.sendMessage(chatId, 'Please choose a valid target currency:', {
+        reply_markup: generateCurrencyKeyboard(),
+      });
+    }
+    return;
+  }
+ 
+  // Handle confirmation or changing currency pair
+  if (text === 'Confirm') {
+    bot.sendMessage(chatId, `Please enter the amount to convert from ${userState[chatId].baseCurrency} to ${userState[chatId].targetCurrency}:`);
+  } else if (text === 'Change Currency Pair') {
+    delete userState[chatId].targetCurrency;
+    bot.sendMessage(chatId, 'Please choose the base currency:', {
+      reply_markup: generateCurrencyKeyboard(),
+    });
+  } else if (userState[chatId].targetCurrency) {
+    const amount = parseFloat(text);
+ 
+    if (!isNaN(amount) && amount > 0) {
+      try {
+        const response = await axios.get(`https://api.exchangerate-api.com/v4/latest/${userState[chatId].baseCurrency}`, {
+          params: { apiKey: exchangerateApiKey },
+        });
+ 
+        const rates = response.data.rates;
+        const convertedAmount = amount * rates[userState[chatId].targetCurrency];
+        bot.sendMessage(chatId, `${amount} ${userState[chatId].baseCurrency} is equal to ${convertedAmount.toFixed(2)} ${userState[chatId].targetCurrency}`);
+      } catch (error) {
+        bot.sendMessage(chatId, 'Sorry, something went wrong. Please try again later.');
+      }
+    } else {
+      bot.sendMessage(chatId, 'Please enter a valid amount.');
+    }
+  }
 });


### PR DESCRIPTION
To add a keyboard at the bottom of the chat for selecting currency pairs and provide the ability to go back and change selections, we can enhance the bot's functionality with a persistent keyboard.